### PR TITLE
カート機能の追加

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,19 +1,79 @@
 class Public::OrdersController < ApplicationController
+
+  before_action :ensure_customer
+  before_action :set_customer_date, only: [:new, :confirm]
+
   def new
+    @order = Order.new
   end
 
   def confirm
-  end
-
-  def complete
+    if params[:order][:address_number] == "1"
+      @order = Order.new(order_params)
+      @order.postal_code = current_customer.postal_code
+      @order.address = current_customer.address
+      @order.name = @customer_name
+    elsif params[:order][:address_number] == "2"
+      @order = Order.new(order_params)
+      @destination = Destination.find(params[:order][:destination_id])
+      @order.postal_code = @destination.postal_code
+      @order.address = @destination.address
+      @order.name = @destination.name
+    elsif params[:order][:address_number] == "3"
+      @order = Order.new(order_params)
+    else
+      render :new
+    end
+    @carts = current_customer.carts.all
+    @total = @carts.inject(0) { |sum, cart| sum + cart.subtotal }
+    @order.postage = 800
+    @total_payment = @total + @order.postage
   end
 
   def create
+    carts = current_customer.carts.all
+    @order = current_customer.orders.new(order_params)
+    if @order.save
+      carts.each do |cart|
+        order_item = OrderItem.new
+        order_item.order_id = @order.id
+        order_item.item_id = cart.item_id
+        order_item.price_with_tax = cart.item.price_with_tax
+        order_item.amount = cart.amount
+        order_item.save
+      end
+      redirect_to orders_complete_path
+      carts.destroy_all
+    else
+      @order = Order.new(order_params)
+      render :new
+    end
   end
 
   def index
   end
 
   def show
+  end
+
+
+  private
+
+  def order_params
+    params.require(:order).permit(:postal_code, :address, :name, :payment_method, :postage, :total_payment)
+  end
+
+  def destination_params
+    params.require(:destination).permit(:customer_id, :postal_code, :address, :name)
+  end
+
+  def ensure_customer
+    redirect_to new_customer_session_path unless customer_signed_in?
+  end
+
+  def set_customer_date
+    @customer = current_customer
+    @customer_name = @customer.last_name + " " + @customer.first_name
+    @customer_address = @customer.postal_code + " " + @customer.address
   end
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -6,4 +6,8 @@ class Destination < ApplicationRecord
     validates :address, presence: true
     validates :name, presence: true
 
+    def address_display
+        '〒' + postal_code + ' ' + address + ' ' + name
+    end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,7 @@ class Order < ApplicationRecord
     belongs_to :customer
     has_many :order_items
 
+    enum payment_method: { credit_card: 0, bank_transfer: 1 }
     enum order_status: { waiting: 0, paid_up: 1, making: 2, preparing: 3, shipped: 4 }
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,6 +3,8 @@ class Order < ApplicationRecord
     belongs_to :customer
     has_many :order_items
 
+    has_many :items, through: :order_items
+
     enum payment_method: { credit_card: 0, bank_transfer: 1 }
     enum order_status: { waiting: 0, paid_up: 1, making: 2, preparing: 3, shipped: 4 }
 

--- a/app/views/public/carts/index.html.erb
+++ b/app/views/public/carts/index.html.erb
@@ -20,11 +20,15 @@
             <% @carts.each do |cart| %>
               <tr id="cart_<%= cart.id %>">
                 <td class="border-right-0"><%= image_tag cart.item.get_image(80,60) %></td>
-                <td class="border-left-0"><%= cart.item.name %></td>
+                <td class="border-left-0">
+                  <%= link_to item_path(cart.item_id) do%>
+                    <%= cart.item.name %>
+                  <% end %>
+                </td>
                 <td>￥<%= cart.item.price_with_tax.to_s(:delimited) %></td>
                 <%= form_with model: cart, url: cart_path(cart.id), local: true, method: :patch do |f| %>
                   <%= f.hidden_field :item_id, :value => cart.item.id %>
-                  <td class="border-right-0"><%= f.select(:amount, *[1..15],{ selected: cart.amount.to_i }, :required => true, class: "form-group mx-sm-3") %>
+                  <td class="border-right-0"><%= f.select(:amount, *[1..cart.amount.to_i],{ selected: cart.amount.to_i }, :required => true, class: "form-group mx-sm-3") %>
                   <td class="border-left-0"><%= f.submit "変更", class: "btn btn-success ml-2" %>
                 <% end %>
                 <td>￥<%= cart.subtotal.to_s(:delimited) %></td>

--- a/app/views/public/carts/index.html.erb
+++ b/app/views/public/carts/index.html.erb
@@ -10,7 +10,7 @@
           <thead class="thead-light">
             <tr>
               <th colspan="2">商品名</th>
-              <th>単価（税込み）</th>
+              <th>単価（税込）</th>
               <th colspan="2">数量</th>
               <th>小計</th>
               <th></th>
@@ -43,7 +43,7 @@
           </tbody>
         </table>
          <div class="text-center mt-5 mb-5">
-          <%= button_to "情報入力に進む", orders_path, class: "btn btn-info btn-lg" %>
+          <%= button_to "情報入力に進む", new_order_path, method: :get, class: "btn btn-info btn-lg" %>
         </div>
       <% else %>
         <h3>お客様のカートに商品はありません</h3>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -27,7 +27,7 @@
             <% elsif @item.is_stopped == false %>
               <%= form_with model: @cart, url: carts_path, method: :post do |f| %>
                 <%= f.hidden_field :item_id, :value => @item.id %>
-                <%= f.select(:amount, *[1..10],{ :include_blank => '個数選択' }, :required => true, class: "form-group mx-sm-3 mb-2") %>
+                <%= f.select(:amount, *[1..30],{ :include_blank => '個数選択' }, :required => true, class: "form-group mx-sm-3 mb-2") %>
                 <%= f.submit "カートに入れる", class: "btn btn-success mb-2" %>
               <% end %>
             <% else %>

--- a/app/views/public/orders/complete.html.erb
+++ b/app/views/public/orders/complete.html.erb
@@ -1,2 +1,8 @@
-<h1>Public::Orders#complete</h1>
-<p>Find me in app/views/public/orders/complete.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="col-8 mx-auto">
+      <h2 class="text-center">ご注文ありがとうございました！</h2>
+      <h4 class="text-center">またのご利用をお待ちしております。</h4>
+    </div>
+  </div>
+</div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -29,14 +29,12 @@
             <tr>
               <td class="font-weight-bold">支払方法</td>
               <td class="pl-3">
-                <%= @order.payment_method %>
-                <!--ja.yml設定終わってから-->
-                <%#<%= @order.payment_methods_i18n %>
+                <%= @order.payment_method_i18n %>
               </td>
             </tr>
             <tr>
               <td class="font-weight-bold">お届け先</td>
-              <td>〒<%= @order.postal_code %></td>
+              <td>〒<%= @order.postal_code.to_s.insert(3, "-") %></td>
               <td><%= @order.address %></td>
               <td><%= @order.name %></td>
             </tr>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -1,2 +1,77 @@
-<h1>Public::Orders#confirm</h1>
-<p>Find me in app/views/public/orders/confirm.html.erb</p>
+<div class='container'>
+  <div class='row'>
+    <div class='col-md-10'>
+      <h3><span class="bg-light">注文情報確認</span></h3>
+      <div class="row">
+        <div class="col-md-9">
+          <table class='table table-bordered mt-3'>
+            <thead class="thead-light">
+              <tr>
+                <th colspan="2">商品名</th>
+                <th>単価（税込）</th>
+                <th>数量</th>
+                <th>小計</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @carts.each do |cart| %>
+                <tr>
+                  <td class="border-right-0"><%= image_tag cart.item.get_image(48,36) %></td>
+                  <td class="border-left-0"><%= cart.item.name %></td>
+                  <td>￥<%= cart.item.price_with_tax.to_s(:delimited) %></td>
+                  <td><%= cart.amount %></td>
+                  <td>￥<%= cart.subtotal.to_s(:delimited) %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <table class='table table-borderless mt-3'>
+            <tr>
+              <td class="font-weight-bold">支払方法</td>
+              <td class="pl-3">
+                <%= @order.payment_method %>
+                <!--ja.yml設定終わってから-->
+                <%#<%= @order.payment_methods_i18n %>
+              </td>
+            </tr>
+            <tr>
+              <td class="font-weight-bold">お届け先</td>
+              <td>〒<%= @order.postal_code %></td>
+              <td><%= @order.address %></td>
+              <td><%= @order.name %></td>
+            </tr>
+          </table>
+          <div class="text-center mt-5 mb-5">
+            <%= form_with model: @order, method: :post, local: true do |f| %>
+              <%= f.hidden_field :postal_code %>
+              <%= f.hidden_field :address %>
+              <%= f.hidden_field :name %>
+              <%= f.hidden_field :payment_method %>
+              <%= f.hidden_field :postage %>
+              <%= f.hidden_field :total_payment, value: @total_payment %>
+              <%= f.submit "注文を確定する", class: "btn btn-success btn-lg" %>
+            <% end %>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <table class='table table-bordered ml-3 mt-3'>
+            <tbody>
+              <tr>
+                <td class="table-light">送料</td>
+                <td>￥<%= @order.postage.to_s(:delimited) %></td>
+              </tr>
+              <tr>
+                <td class="table-light">商品合計</td>
+                <td>￥<%= @total.to_s(:delimited) %></td>
+              </tr>
+              <tr>
+                <td class="table-light">請求金額</td>
+                <td>￥<%= @total_payment.to_s(:delimited) %></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -10,16 +10,13 @@
           <tr>
             <td class="pl-3">
               <%= f.radio_button :payment_method, Order.payment_methods.key(0) %>
-              <%= f.label :payment_method, "クレジットカード" %>
-              <!--ja.yml設定終わってから-->
-              <%#<%= f.label :payment_method, Order.payment_methods_i18n[:credit_card] %>
+              <%= f.label :payment_method, Order.payment_methods_i18n[:credit_card] %>
             </td>
           </tr>
           <tr>
             <td class="pl-3">
               <%= f.radio_button :payment_method, Order.payment_methods.key(1) %>
-              <%= f.label :payment_method, "銀行振込" %>
-              <%#<%= f.label :payment_method, Order.payment_methods_i18n[:bank_transfer]%>
+              <%= f.label :payment_method, Order.payment_methods_i18n[:bank_transfer]%>
             </td>
           </tr>
           <tr>
@@ -45,7 +42,7 @@
           </tr>
           <tr>
             <td class="pl-5">
-              <%= f.select :destination_id, options_from_collection_for_select(@customer.destinations.all, :id, :address_display), { :include_blank => '住所を選択してください' } %>
+              <%= f.select :destination_id, options_from_collection_for_select(@customer.destinations.all, :id, :address_display), { :include_blank => '住所を選択してください' }, class: "form-control" %>
             </td>
           </tr>
           <tr>
@@ -55,16 +52,22 @@
             </td>
           </tr>
           <tr>
-            <td class="pl-5"><%= f.label :postal_code, "郵便番号(ハイフンなし)" %></td>
-            <td><%= f.text_field :postal_code %></td>
+            <td class="pl-5">
+              <%= f.label :postal_code, "郵便番号(ハイフンなし)" %>
+              <%= f.text_field :postal_code %>
+            </td>
           </tr>
           <tr>
-            <td class="pl-5"><%= f.label :address, "住所" %></td>
-            <td><%= f.text_field :address %></td>
+            <td class="pl-5">
+              <%= f.label :address, "住所" %>
+              <%= f.text_field :address %>
+            </td>
           </tr>
           <tr>
-            <td class="pl-5"><%= f.label :name, "宛名" %></td>
-            <td><%= f.text_field :name %></td>
+            <td class="pl-5">
+              <%= f.label :name, "宛名" %>
+              <%= f.text_field :name %>
+            </td>
           </tr>
           <tr>
             <td colspan= "2", class="text-center mt-5 mb-5">

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -18,7 +18,7 @@
           <p class="font-weight-bold">お届け先</p>
           <div class="form-group">
             <div class="pl-3">
-              <%= f.radio_button :address_number, 1 %>
+              <%= f.radio_button :address_number, 1, {:checked => true} %>
               <%= f.label :address_number_1, "ご自身の住所" %>
             </div>
             <div class="pl-5">〒<%= @customer_address %></div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -1,2 +1,78 @@
-<h1>Public::Orders#new</h1>
-<p>Find me in app/views/public/orders/new.html.erb</p>
+<div class='container'>
+  <div class='row'>
+    <div class='col-md-10'>
+      <h3><span class="bg-light">注文情報入力</span></h3>
+      <%= form_with model: @order, url: orders_confirm_path, local: true, method: :post do |f| %>
+        <table class='table table-borderless table-sm mt-3'>
+          <tr>
+            <th><%= f.label :payment_method, "支払方法", class: "font-weight-bold" %></th>
+          </tr>
+          <tr>
+            <td class="pl-3">
+              <%= f.radio_button :payment_method, Order.payment_methods.key(0) %>
+              <%= f.label :payment_method, "クレジットカード" %>
+              <!--ja.yml設定終わってから-->
+              <%#<%= f.label :payment_method, Order.payment_methods_i18n[:credit_card] %>
+            </td>
+          </tr>
+          <tr>
+            <td class="pl-3">
+              <%= f.radio_button :payment_method, Order.payment_methods.key(1) %>
+              <%= f.label :payment_method, "銀行振込" %>
+              <%#<%= f.label :payment_method, Order.payment_methods_i18n[:bank_transfer]%>
+            </td>
+          </tr>
+          <tr>
+            <th class="font-weight-bold">お届け先</th>
+          </tr>
+          <tr>
+            <td class="pl-3">
+              <%= f.radio_button :address_number, 1 %>
+              <%= f.label :address_number_1, "ご自身の住所" %>
+            </td>
+          </tr>
+          <tr>
+            <td class="pl-5"><%= @customer_address %></td>
+          </tr>
+          <tr>
+            <td class="pl-5"><%= @customer_name %></td>
+          </tr>
+          <tr>
+            <td class="pl-3">
+              <%= f.radio_button :address_number, 2 %>
+              <%= f.label :address_number_2, "登録済住所から選択" %>
+            </td>
+          </tr>
+          <tr>
+            <td class="pl-5">
+              <%= f.select :destination_id, options_from_collection_for_select(@customer.destinations.all, :id, :address_display), { :include_blank => '住所を選択してください' } %>
+            </td>
+          </tr>
+          <tr>
+            <td class="pl-3">
+                <%= f.radio_button :address_number, 3 %>
+                <%= f.label :address_number_3, "新しいお届け先" %>
+            </td>
+          </tr>
+          <tr>
+            <td class="pl-5"><%= f.label :postal_code, "郵便番号(ハイフンなし)" %></td>
+            <td><%= f.text_field :postal_code %></td>
+          </tr>
+          <tr>
+            <td class="pl-5"><%= f.label :address, "住所" %></td>
+            <td><%= f.text_field :address %></td>
+          </tr>
+          <tr>
+            <td class="pl-5"><%= f.label :name, "宛名" %></td>
+            <td><%= f.text_field :name %></td>
+          </tr>
+          <tr>
+            <td colspan= "2", class="text-center mt-5 mb-5">
+              <%= f.submit "確認画面へ進む", class: "btn btn-info btn-lg" %>
+            </td>
+          </tr>
+        </table>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -2,80 +2,58 @@
   <div class='row'>
     <div class='col-md-10'>
       <h3><span class="bg-light">注文情報入力</span></h3>
-      <%= form_with model: @order, url: orders_confirm_path, local: true, method: :post do |f| %>
-        <table class='table table-borderless table-sm mt-3'>
-          <tr>
-            <th><%= f.label :payment_method, "支払方法", class: "font-weight-bold" %></th>
-          </tr>
-          <tr>
-            <td class="pl-3">
+      <div class="form-row">
+        <%= form_with model: @order, url: orders_confirm_path, local: true, method: :post do |f| %>
+          <div class="form-group">
+            <%= f.label :payment_method, "支払方法", class: "font-weight-bold" %></th>
+            <div class="pl-3">
               <%= f.radio_button :payment_method, Order.payment_methods.key(0) %>
               <%= f.label :payment_method, Order.payment_methods_i18n[:credit_card] %>
-            </td>
-          </tr>
-          <tr>
-            <td class="pl-3">
+            </div>
+            <div class="pl-3">
               <%= f.radio_button :payment_method, Order.payment_methods.key(1) %>
               <%= f.label :payment_method, Order.payment_methods_i18n[:bank_transfer]%>
-            </td>
-          </tr>
-          <tr>
-            <th class="font-weight-bold">お届け先</th>
-          </tr>
-          <tr>
-            <td class="pl-3">
+            </div>
+          </div>
+          <p class="font-weight-bold">お届け先</p>
+          <div class="form-group">
+            <div class="pl-3">
               <%= f.radio_button :address_number, 1 %>
               <%= f.label :address_number_1, "ご自身の住所" %>
-            </td>
-          </tr>
-          <tr>
-            <td class="pl-5"><%= @customer_address %></td>
-          </tr>
-          <tr>
-            <td class="pl-5"><%= @customer_name %></td>
-          </tr>
-          <tr>
-            <td class="pl-3">
+            </div>
+            <div class="pl-5">〒<%= @customer_address %></div>
+            <div class="pl-5"><%= @customer_name %></div>
+          </div>
+          <div class="form-group">
+            <div class="pl-3">
               <%= f.radio_button :address_number, 2 %>
               <%= f.label :address_number_2, "登録済住所から選択" %>
-            </td>
-          </tr>
-          <tr>
-            <td class="pl-5">
-              <%= f.select :destination_id, options_from_collection_for_select(@customer.destinations.all, :id, :address_display), { :include_blank => '住所を選択してください' }, class: "form-control" %>
-            </td>
-          </tr>
-          <tr>
-            <td class="pl-3">
-                <%= f.radio_button :address_number, 3 %>
-                <%= f.label :address_number_3, "新しいお届け先" %>
-            </td>
-          </tr>
-          <tr>
-            <td class="pl-5">
-              <%= f.label :postal_code, "郵便番号(ハイフンなし)" %>
-              <%= f.text_field :postal_code %>
-            </td>
-          </tr>
-          <tr>
-            <td class="pl-5">
-              <%= f.label :address, "住所" %>
-              <%= f.text_field :address %>
-            </td>
-          </tr>
-          <tr>
-            <td class="pl-5">
-              <%= f.label :name, "宛名" %>
-              <%= f.text_field :name %>
-            </td>
-          </tr>
-          <tr>
-            <td colspan= "2", class="text-center mt-5 mb-5">
-              <%= f.submit "確認画面へ進む", class: "btn btn-info btn-lg" %>
-            </td>
-          </tr>
-        </table>
-      <% end %>
+            </div>
+            <div class="pl-5">
+              <%= f.select :destination_id, options_from_collection_for_select(@customer.destinations.all, :id, :address_display), class: "form-control" %>
+            </div>
+          </div>
+          <div class="pl-3">
+            <%= f.radio_button :address_number, 3 %>
+            <%= f.label :address_number_3, "新しいお届け先" %>
+          </div>
+          <div class="form-group row">
+            <%= f.label :postal_code, "郵便番号(ハイフンなし)", class: "col-sm-6 pl-5" %>
+            <%= f.text_field :postal_code, class: "col-sm-4" %>
+          </div>
+          <div class="form-group row">
+            <%= f.label :address, "住所", class: "col-sm-6 pl-5" %>
+            <%= f.text_field :address, class: "col-sm-6" %>
+          </div>
+          <div class="form-group row">
+            <%= f.label :name, "宛名", class: "col-sm-6 pl-5" %>
+            <%= f.text_field :name, class: "col-sm-4" %>
+          </div>
+          <div class="text-center mt-5 mb-5">
+            <%= f.submit "確認画面へ進む", class: "btn btn-info btn-lg" %>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,9 @@
 ja:
   enums:
     order:
+      payment_method:
+        credit_card: "クレジットカード"
+        bank_transfer: "銀行振込"
       order_status:
         waiting: "入金待ち"
         paid_up: "入金確認"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,9 @@ Rails.application.routes.draw do
     patch 'customers/deactivate'
     delete 'carts/destroy_all', to: 'carts#destroy_all', as: 'carts_destroy_all'
     resources :carts, except: [:show,:new,:edit]
+    post 'orders/confirm', to: 'orders#confirm', as: 'orders_confirm'
+    get 'orders/complete', to: 'orders#complete', as: 'orders_complete'
     resources :orders, except: [:edit,:update,:destroy]
-    post 'orders/confirm'
-    get 'orders/complete'
     resources :destinations, except: [:show,:new]
   end
 


### PR DESCRIPTION
カート機能を追加
ja.ymlに支払方法の日本語訳を追加しました。

商品追加数の挙動、スクラムで相談した通りのものになっているとはおもいますが、逆にカート画面で個数を増やすことが不便になっているので操作してみて感想聞かせてください。

※注文情報入力画面のバリデーションはされていません。
郵便番号の数字のみ受け付けもバリデーションで{only_integer: true}でたぶん指定可能なので宮本さんお願いします＞＜